### PR TITLE
Update verkkaaja.sh

### DIFF
--- a/verkkaaja.sh
+++ b/verkkaaja.sh
@@ -56,7 +56,7 @@ fi
 echo Trying to add product to shopping cart...
 # Release the hounds
 while true; do
-  ERRORS=$(curl -s 'https://www.verkkokauppa.com/api/v2/cart/'$CART'?pid='$SKU'&quantity=1' \
+  ERRORS=$(curl -s "https://www.verkkokauppa.com/api/v2/cart/${CART}?pid=${SKU}&quantity=1" \
     -X PUT \
     -H 'Authorization: Bearer '$TOKEN \
     -H 'Origin: https://www.verkkokauppa.com' \


### PR DESCRIPTION
Unsafe string concatenation.
Response from curl on line 28 isn't properly sanitized, so a malicious response from the server can inject new parameters for curl eg.
```
{"cartuuid":" --data-binary \"@/etc/passwd\" -o /tmp/output_of_my_choice "}
```
ends up sending users /etc/passwd to the server as data upload and outputting response to a file in /tmp.